### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ lines:
 
 ```
 Section "InputClass"
-	Identifier "Parblo Coast 10"
+	Identifier "ParbloCoast10"
 	MatchUSBID "0b57:8534"
 	MatchDevicePath "/dev/input/event*"
 	Driver "wacom"


### PR DESCRIPTION
I think constant "NAME" in parblo-coast10.c and the identifier in xorg.conf should be the same.(Please know that English is not my native language, and I may make some confusing mistakes.)
https://github.com/Skrylar/parblo-coast/blob/c65b6143f2824f2a15d1056331ead38d6e165585/parblo-coast10.c#L42